### PR TITLE
[Bugfix] Deep clone order items to avoid mutating local state.

### DIFF
--- a/coffee_run/lib/view_models/new_order_run_view_model.dart
+++ b/coffee_run/lib/view_models/new_order_run_view_model.dart
@@ -70,7 +70,7 @@ class NewOrderViewModel extends ChangeNotifier {
 
   // Take a previous order and populate this order with it.
   void populateFromPrevOrder(CoffeeOrder order) {
-    orderItems = order.items;
+    orderItems = List.from(order.items);
     memberIdValidations = List.generate(order.items.length, (index) => true);
     notifyListeners();
   }

--- a/coffee_run/lib/view_models/new_order_run_view_model.dart
+++ b/coffee_run/lib/view_models/new_order_run_view_model.dart
@@ -70,7 +70,10 @@ class NewOrderViewModel extends ChangeNotifier {
 
   // Take a previous order and populate this order with it.
   void populateFromPrevOrder(CoffeeOrder order) {
-    orderItems = List.from(order.items);
+    // Perform a deep copy of order items
+    orderItems = List.of(order.items)
+        .map((e) => OrderItem(e.name, e.cost, e.memberId, id: e.id))
+        .toList();
     memberIdValidations = List.generate(order.items.length, (index) => true);
     notifyListeners();
   }


### PR DESCRIPTION
When starting a new order from a previous order there was an issue where our new order items array pointed to our previous order item array instead of creating a new array altogether.  The result of this led to the new order and previous order items being synchronized locally.  This wasn't ideal.  This request correctly constructs a deep copy of the previous order items.